### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/iphone/build.py
+++ b/iphone/build.py
@@ -199,7 +199,7 @@ def package_module(manifest,mf,config):
 	libname = 'lib%s.a' % moduleid
 	zf.write('build/%s' % libname, '%s/%s' % (modulepath,libname))
 	docs = generate_doc(config)
-	if docs!=None:
+	if docsis notNone:
 		for doc in docs:
 			for file, html in doc.iteritems():
 				filename = string.replace(file,'.md','.html')


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:Parse?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:runt18:Parse?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
